### PR TITLE
fix(lint): resolve biome errors blocking deploy

### DIFF
--- a/assets/js/system-core.js
+++ b/assets/js/system-core.js
@@ -170,7 +170,7 @@
 
   window.openOperationModal = (opId) => {
     const uc = window.globalIntel ? window.globalIntel.unitcommander : null;
-    if (!uc || !uc.campaigns) return;
+    if (!uc?.campaigns) return;
     const op = uc.campaigns.find((c) => c.id === opId);
     if (!op) return;
 

--- a/scripts/lib/rcon.js
+++ b/scripts/lib/rcon.js
@@ -1,6 +1,7 @@
 import { exec, spawn } from 'node:child_process';
 import util from 'node:util';
 import 'dotenv/config';
+
 const execPromise = util.promisify(exec);
 
 class RconManager {


### PR DESCRIPTION
Fixes the lint errors that fail the `Deploy UKSF Portal` workflow after the dependency fix:

- `assets/js/system-core.js:173` — useOptionalChain: use optional chaining for the campaign guard
- `scripts/lib/rcon.js:4` — organizeImports: add blank line after imports

These errors were previously masked by the npm install ERESOLVE failure (now fixed). `biome check` passes on the full repo.