### PR TITLE
ops: upgrade node to 22 for supabase native websocket

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Check Runner Health
         env:

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
The build fails with 'Node.js detected but native WebSocket not found' from @supabase/realtime-js. Supabase v2.97+ requires Node 22+ for native WebSocket support.

Upgrade node-version to 22 in hugo.yaml and health.yml.