### PR TITLE
fix(build): use tailwind cli instead of hugo postCSS

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -1,4 +1,4 @@
-{{ $css := resources.Get "css/input.css" | postCSS }}
+{{ $css := resources.Get "css/output.css" }}
 {{ if not hugo.IsServer }}
     {{ $css = $css | fingerprint }}
 {{ end }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,10 @@
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
         "tailwindcss": "^4.3.3"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6705,7 +6709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -6729,7 +6732,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "fetch-data": "node scripts/fetch-external-data.js",
     "start": "hugo server --environment development",
     "dev": "NODE_ENV=development concurrently -n \"HUGO,INTEL,RCON,REGISTRY\" -c \"blue,yellow,red,green\" \"npm run start\" \"npm run watch:intel\" \"npm run service:rcon\" \"npm run service:registry\"",
-    "build": "npm run fetch-data && node scripts/generate-stats.js && hugo --environment production --gc --minify",
-    "build:dev": "npm run fetch-data && node scripts/generate-stats.js && hugo --environment development --gc --minify",
+    "build": "npm run build:css && npm run fetch-data && node scripts/generate-stats.js && hugo --environment production --gc --minify",
+    "build:dev": "npm run build:css && npm run fetch-data && node scripts/generate-stats.js && hugo --environment development --gc --minify",
     "watch:intel": "node -e \"setInterval(() => { try { require('./scripts/fetch-external-data.js') } catch(e){} }, 60000);\"",
     "service:rcon": "node services/rcon-bridge.js",
     "service:registry": "node services/registry-service.js",
     "lint": "biome check assets/js scripts",
     "format": "biome format --write assets/js scripts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:css": "tailwindcss -i assets/css/input.css -o assets/css/output.css --minify"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.11",
@@ -49,5 +50,9 @@
     "glob": {
       "minimatch": ">=10.2.3"
     }
+  },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0"
   }
 }


### PR DESCRIPTION
Fixes the `Deploy UKSF Portal` workflow failing since May 2026.

**Root cause:** Hugo's `postCSS` pipeline is incompatible with Tailwind v4 — the `@tailwindcss/postcss` plugin loads `lightningcss` native module which fails to resolve inside hugo's postcss subprocess (npm CLI bug with optional platform deps).

**Fix:**
- Build CSS with `@tailwindcss/cli` (`build:css` script) before hugo runs
- Template references the pre-built `assets/css/output.css` (fingerprinted) instead of hugo's postCSS transform
- Added explicit `optionalDependencies` for `lightningcss-linux-x64-gnu` to ensure the native binary installs on CI

Verified: full hugo build succeeds locally, CSS is fingerprint-generated correctly.